### PR TITLE
Changes version number to 0.3.4.0 to match the PyPi release.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "slycot" %}
-{% set version = "0.3.4" %}
+{% set version = "0.3.4.0" %}
 {% set sha256 = "63e648b2be8c8ba0322a5fe286bdcf0e8d28a0c12e9ab1510f2a8725fc1283ec" %}
 
 package:
@@ -10,17 +10,17 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   # for testing still, should switch over to pypi package when available
   # url: https://github.com/python-control/Slycot/archive/v{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.0.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   # problem with python2.7 configuration on windows and osx
   skip: true                     # [win and py==27]
   skip: true                     # [osx and py==27]
 
 # TODO: (later) solve imperfections
-# * the clang compiler on osx gives a link error, thought to be related to 
+# * the clang compiler on osx gives a link error, thought to be related to
 #   cmake and env. Try later when this may be fixed. Alternative: gcc
 # * the mkl library does not link on osx or win. Alternative: openblas
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   # problem with python2.7 configuration on windows and osx
   skip: true                     # [win and py==27]
   skip: true                     # [osx and py==27]


### PR DESCRIPTION
The PyPi release (and git tag) for slycot mistakenly included the extra
zero. We should have the conda-forge package match it until fixed
upstream.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
